### PR TITLE
Correctly accumulate prefixes when recursing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,4 +10,5 @@
 
 # Please keep the list sorted.
 
+Adrien Siami <adrien@siami.fr>
 Ross Light <ross@zombiezen.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Permit hyphens as part of controller suffix
   ([#3](https://github.com/zombiezen/esbuild-plugin-stimulus/issues/3))
+- Use all parent components during directory recursion
+  ([#6](https://github.com/zombiezen/esbuild-plugin-stimulus/issues/6))
+- Rewrite underscored directories to hyphens
+  ([#6](https://github.com/zombiezen/esbuild-plugin-stimulus/issues/6))
 
 ## [0.1.0][] - 2021-03-17
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -19,4 +19,5 @@
 # same person when interacting with Git.
 
 # Please keep the list sorted.
+Adrien Siami <adrien@siami.fr>
 Ross Light <ross@zombiezen.com>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -104,7 +104,7 @@ describe('directories', () => {
     expect(got).toEqual([{identifier: 'foo--bar', className: 'FooBar'}]);
   });
 
-  test.skip('are walked recursively', async () => {
+  test('are walked recursively', async () => {
     const got = await listDefinitions({
       'foo/bar/baz_controller.js': 'export default class FooBarBaz {}',
     });
@@ -118,7 +118,7 @@ describe('directories', () => {
     expect(got).toEqual([{identifier: 'foo-bar--baz', className: 'FooBarBaz'}]);
   });
 
-  test.skip('convert underscores to hyphens', async () => {
+  test('convert underscores to hyphens', async () => {
     const got = await listDefinitions({
       'foo_bar/baz_controller.js': 'export default class FooBarBaz {}',
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export const stimulusPlugin = (): Plugin => ({
           if (ent.isDirectory()) {
             result.push(...await walk(
               path.join(dir, ent.name),
-              prefix + ent.name + '--',
+              prefix + ent.name.replace(/_/g, '-') + '--',
               moduleDir + '/' + ent.name,
             ));
             continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export const stimulusPlugin = (): Plugin => ({
           if (ent.isDirectory()) {
             result.push(...await walk(
               path.join(dir, ent.name),
-              ent.name + '--',
+              prefix + ent.name + '--',
               moduleDir + '/' + ent.name,
             ));
             continue;


### PR DESCRIPTION
Fix for the issues mentioned in #6 regarding accumulating the prefix when recursing multiple times through directories and `-` vs `_` in the prefix name