### PR TITLE
Add `watchDirs` `onResolve`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/jest": "^27.0.1",
     "@types/node": "^14.14.35",
-    "esbuild": "^0.9.2",
+    "esbuild": "^0.10.0",
     "jest": "^27.1.1",
     "ts-jest": "^27.0.5",
     "typescript": "^4.2.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,9 +68,11 @@ export const stimulusPlugin = (): Plugin => ({
 
     build.onResolve({ filter: /^stimulus:./ }, args => {
       const pathArg = args.path.substring('stimulus:'.length);
+      const resolvedPath = path.join(args.resolveDir, pathArg.replace(/\//g, path.sep));
       return {
-        path: path.join(args.resolveDir, pathArg.replace(/\//g, path.sep)),
+        path: resolvedPath,
         namespace,
+        watchDirs: [resolvedPath],
       };
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,11 +68,9 @@ export const stimulusPlugin = (): Plugin => ({
 
     build.onResolve({ filter: /^stimulus:./ }, args => {
       const pathArg = args.path.substring('stimulus:'.length);
-      const resolvedPath = path.join(args.resolveDir, pathArg.replace(/\//g, path.sep));
       return {
-        path: resolvedPath,
+        path: path.join(args.resolveDir, pathArg.replace(/\//g, path.sep)),
         namespace,
-        watchDirs: [resolvedPath],
       };
     });
 
@@ -81,7 +79,9 @@ export const stimulusPlugin = (): Plugin => ({
         controllerName: string;
         modulePath: string;
       }
+      const visitedDirs = new Set<string>();
       const walk = async (dir: string, prefix: string, moduleDir: string): Promise<Controller[]> => {
+        visitedDirs.add(dir);
         let files;
         try {
           files = await promisify(readdir)(dir, {withFileTypes: true});
@@ -125,6 +125,7 @@ export const stimulusPlugin = (): Plugin => ({
         contents,
         loader: 'js',
         resolveDir: args.path,
+        watchDirs: Array.from(visitedDirs),
       };
     });
   },


### PR DESCRIPTION
Hello, we use and love this plugin 🙌 

One problem we run into during local development is that adding a new stimulus controller requires a server restart in order for esbuild to pick up the new controller.

**Current behavior:**
- add `foo_controller.js` to `/.app/path_to_controllers/foo_controller.js`
- no rebuild ❌ 
- foo_controller not picked up without restarting server ❌ 

We surmised that the issue stemmed from the plugin [not returning watchDirs](https://esbuild.github.io/plugins/#on-resolve-results).

This PR returns the `watchDirs` of the `resolvedPath` `onResolve`.

**New behavior:**
- add `foo_controller.js` to `/.app/path_to_controllers/foo_controller.js`
- get a rebuild ✅ 
- foo_controller picked up without restarting server ✅ 
 
 Would love to discuss! Thanks for considering this PR.